### PR TITLE
BOJ2075_n번째의수_실버2_조재은

### DIFF
--- a/study/baekjoon/week2/BOJ2075_n번째의수/백준2075_n번쨰의수_실버2_조재은.py
+++ b/study/baekjoon/week2/BOJ2075_n번째의수/백준2075_n번쨰의수_실버2_조재은.py
@@ -1,0 +1,19 @@
+import heapq
+
+n = int(input())
+
+heap = []
+
+for _ in range(n):
+    numbers = map(int, input().split())
+    for number in numbers:
+        if len(heap) < n :                            # 리스트를 최소 힙처럼 다룰 수 있도록 하기 때문에, 빈 리스트를 heapq의 함수를 호출할 때마다 리스트에 인자를 넘겨야 한다.
+            heapq.heappush(heap, number)        # number를 heap에 추가
+            print(heap)
+        else:
+            if heap[0] < number:
+                heapq.heappop(heap)                   # heappop 함수는 가장 작은 원소를 pop
+                heapq.heappush(heap, number)
+                print(heap)
+
+print(heap[0])


### PR DESCRIPTION
n의 최대 크기가 1500으로 시간 제한만 없으면 숫자 모두를 받아서 정렬하는 방식으로 사용해도 된다.

n^2개의 숫자 모두를 배열에 저장하고 그 후에 문제 조건에 따라 무언가를 처리하는 방식으로 해당 문제를 풀기 어렵습니다.
이에 n^2의 숫자들을 모두 살펴보면서 로직을 수행하되 이러한 입력들을 크기가 n 짜리 우선순위 큐에서 처리해주면 문제를 해결할 수 있다.

### 문제풀이
현재 확인하고 있는 숫자에 대해서,,,(n^2의 숫자롤 하나하나 확인함)
1. 우선순위 큐 안에 들어있는 원소의 개수가 n개 미만이면 => 우선순위 큐에 넣는다
2. 우선순위 큐 안에 들어있는 원소의 개수가 n개 라면 
 2-1) 현재 확인하고 있는 숫자가 우선순위 큐의 최솟값보다 작은 경우 => 무시한다.   
 2-2) 그 외의 경우 => 우선순의 큐의 최솟값을 제거하고 현재 확인하고 있는 숫자를 우선순위 큐에 삽입한다.