### PR TITLE
BOJ20291_파일정리_실버3_조재은

### DIFF
--- a/study/baekjoon/week3/BOJ20291_파일정리/BOJ20291_파일정리_실버3_조재은.py
+++ b/study/baekjoon/week3/BOJ20291_파일정리/BOJ20291_파일정리_실버3_조재은.py
@@ -1,0 +1,18 @@
+import os
+from collections import Counter
+# 파일 개수 n 입력받기
+n = int(input())
+file_names = []
+# 파일 이름 입력받기
+for _ in range(n):
+    file_names.append(input())
+results = []
+# 파일 이름에서 확장자 추출 (점 제거)
+for file_name in file_names:
+    result = os.path.splitext(file_name)[1][1:]  # 확장자 앞의 점 제거
+    results.append(result)
+# 확장자별 카운트
+file_counter = Counter(results)
+# 확장자와 카운트 출력 (점 제거된 확장자)
+for ext, count in sorted(file_counter.items()):  # 사전 순으로 정렬
+    print(f"{ext} {count}")


### PR DESCRIPTION
* 파이썬 표준 라이브러리 중 하나인 os 라이브러리의 path 모듈에 있는 splitext를 사용
* splitext는 파일명을 입력으로 받아 확장자 전까지의 파일 이름과 확장자를 분리해서 반환해준다.
`_file_name, ext = os.path.splitext(file_name)`
* 파일의 경로를 os.path.splitext 함수의 매개변수로 넣어주시면 두 개의 값이 반환되는데 그 중 두번째 반환값이 파일의 확장자입니다. 참고로 두번째 반환값을 나타내려면 os.path.splitext(file_path) 뒤에 [1]을 붙여줘야 합니다. 첫번째 반환값은 경로에서 확장자를 뺀 나머지 부분입니다. 

### 풀이
파일 이름에서 확장자 추출 (점 제거)
=> result = os.path.splitext(file_name)[1][1:]
* [1:]: 확장자 부분에서 첫 번째 문자를 제외한 나머지 부분을 선택합니다. 즉, 확장자에서 마침표("." )를 제외한 부분을 선택합니다. 위의 예에서는 "txt"가 선택됩니다.

확장자별 카운트
=> file_counter = Counter(results)

확장자와 카운트 출력 (점 제거된 확장자)
=> for ext, count in sorted(file_counter.items()):  # 사전 순으로 정렬
    print(f"{ext} {count}")