### PR TITLE
BOJ1260_DFS와 BFS_실버2_조재은

### DIFF
--- a/study/week4/BOJ1260_DFS와 BFS/BOJ1260_DFS와 BFS_실버2_조재은.py
+++ b/study/week4/BOJ1260_DFS와 BFS/BOJ1260_DFS와 BFS_실버2_조재은.py
@@ -1,0 +1,51 @@
+from collections import deque
+
+# n : 정점의 개수, m : 간선의 개수, v : 탐색 시작 번호
+n, m, v = map(int, input().split())
+
+# 초기값을 false로 만들어  그래프 선언
+graph = [[False] * (n+1) for _ in range(n+1)]
+
+# 연결된 정점을 입력
+for i in range(m):
+    x, y = map(int, input().split())
+    graph[x][y] = 1
+    graph[y][x] = 1
+
+# dfs와 bfs 그래프의 방문 여부를 담을 리스트
+visited1 = [False] * (n+1)
+visited2 = [False] * (n+1)
+
+# dfs 알고리즘
+def dfs(v):
+    # 방문 처리
+    visited1[v] = True
+    # 방문 후, 정점 출력
+    print(v, end=" ")
+    # 방문 기록이 업고, 인덱스에 값이 있다면 (= 연결되어 있다면)
+    for i in range(1, n+1):
+        if not visited1[i] and graph[v][i] == 1:
+            # 방문한다. ** 재귀함수 사용
+            # 호출될 때마다 visited는 1이 되고, 재귀되어 v에 i가 들어간다.
+            dfs(i)
+
+# bfs 알고리즘
+def bfs(v):
+    # 방문할 곳을 순서대로 넣을 큐
+    q = deque([v])
+    # 방문 처리
+    visited2[v] = True
+    # 큐 안에 데이터가 없을 때 까지 실행
+    while q:
+        # 큐 맨 앞에 있는 값을 꺼내서 출력
+        v = q.popleft()
+        print(v, end=" ")
+        for i in range(1, n+1):
+            # 방문기록이 없고, 인덱스 값이 있다면(= 연결되어 있다면)
+            if not visited2[i] and graph[v][i] == 1:
+                # 큐에 추카한다.
+                q.append(i)
+                visited2[i] = True
+dfs(v)
+print()
+bfs(v)


### PR DESCRIPTION
### 문제풀이
1. 입력값 받기
2. 그래프 선언하기
3. dfs 함수 만들기
4. bfs 함수 만들기
5. 함수 실행

5개의 간선으로 이루어진 그래프
![image](https://github.com/96Hong2/algorithm-study/assets/65579171/523348bb-dfdf-4c3e-8ffb-562cdda02c45)
![image](https://github.com/96Hong2/algorithm-study/assets/65579171/18e97df9-95e3-43e6-b0f9-007d3be4a1ca)

1과 2가 연결되어 있으므로 [1,2] [2,1] 2칸 모두 1로 표시한다.

방문 유무를 담는 리스트 visited 선언
`visited = [False] * (n+1)`
- False => 방문 X
- True => 방문 O
- (n+1) => 정점은 1~4까지이고, 0번째 인덱스를 사용하지 않기 위해서다

[DFS(깊이 우선 탐색)탐색 순서도]
- 인접한 노드 중 시작점 v부터 숫자가 작은 노드부터 방문하고, 이미 방문했다면 다시 돌아가 인접노드를 찾는다
![image](https://github.com/96Hong2/algorithm-study/assets/65579171/76fdea44-2e58-408e-88e9-208a6938fd2b)

그래서 1 > 2 > 4 > 3 순으로 방문한다.

[BFS(깊이 우선 탐색) 탐색 순서도]
![image](https://github.com/96Hong2/algorithm-study/assets/65579171/061d0128-3f2e-4185-9b83-06e5ac47e94a)

1. 1번 노드 방문 후 큐에 삽입
2. 가장 앞에 있는 노드 1을 pop 한 후, 인접 노드 2,3,4 모드를 q에 append
3. 가장 앞에 있는 노드 2을 pop 한 후, 인접 노드 모두 방문하였으므로 append 하지 않음
4. 가장 앞에 있는 노드 3을 pop 한 후, 인접 노드 모두 방문하였으므로 append 하지 않음
5. 가장 앞에 있는 노드 4을 pop 한 후, 인접 노드 모두 방문하였으므로 append 하지 않음
6. q는 공백이 되며 종료

그래서 1 > 2 > 3 > 4 순으로 방문한다.

BFS 정리!
1. q 선언은 deque 사용
2. whilw문을 돌아 q에 값을 얻을 때 까지 반복하는 로직 구성
3. q 맨 앞에 있는 정점을 popleft하고 그 아이를 기준으로 방문할 수 있는 모든 장점들을 append한다. 즉, 뒤에다가 계속 붙여준다
4. 붙인 정점들 중 가장 앞에 있는 아이를 꺼내고, 넣고 꺼내고 넣고 반복한다.
5. 새로운 노드가 추가되지 않으면, 그 때까지 큐에 남아있는 녀석들을 모두 비우고 함수를 빠져나온다

### DFS, BFS 문제풀이
DFS : 스택과 재귀함수로 구현
BFS : deque, while로 구현 -> 시간복잡도가 낮은 popleft를 사용하자~
graph를 표현할 때 인덱스 0번을 비우고 하면 편하다.
