### PR TITLE
BOJ9655_돌_게임_실버5_권은홍

### DIFF
--- a/study/baekjoon/week7/BOJ9655_돌_게임/BOJ9655_돌_게임_실버5_권은홍.java
+++ b/study/baekjoon/week7/BOJ9655_돌_게임/BOJ9655_돌_게임_실버5_권은홍.java
@@ -1,0 +1,12 @@
+package study.baekjoon.week7.BOJ9655_돌_게임;
+import java.util.Scanner;
+
+public class BOJ9655_돌_게임_실버5_권은홍 {
+    public static void main(String[] args)
+    {
+        Scanner scanner = new Scanner(System.in);
+        int N = scanner.nextInt();
+        if(N%2 == 0) System.out.println("CY");
+        else System.out.println("SK");
+    }
+}


### PR DESCRIPTION
- 남은 돌이 4의 배수가 되면 후공이 승리한다. 1>상근, 2>창영, 3>상근이며,
4배수+1일 때는 상근이가 처음에 1을 불러 4배수만 남기면 되므로 상근이가 이기고, 
4배수+2일 때는 상근이가 1을 하면 창영이가 1, 상근이가 3을 하면 창영이가 3을 불러 4배수만 남기므로 창영이가 이긴다.
4배수+3일 때는 상근이가 3을 불러 4배수만 남겨서 상근이가 이긴다.
따라서 패턴을 보면 짝수일 때는 창영이가 이기고, 홀수일 때는 상근이가 이긴다.
1. Scanner로 N받는다
2. N을 2로 나눈 나머지가 있을 때 SK를, 없을 때 CY를 출력한다.