### PR TITLE
BOJ29515_비밀번호_찾기_실버3_조재은

### DIFF
--- a/study/baekjoon/week7/BOJ9461_파도반_수열/BOJ9461_파도반_수열_실버3_조재은.py
+++ b/study/baekjoon/week7/BOJ9461_파도반_수열/BOJ9461_파도반_수열_실버3_조재은.py
@@ -1,0 +1,14 @@
+P = [0 for i in range(101)] # 1 <= N <= 100
+
+P[1] = 1
+P[2] = 1
+P[3] = 1
+
+# P[N] = P[N-3] + P[N-2] 규칙 성립
+for i in range(4, 100+1):
+    P[i] = P[i-3] + P[i-2]
+
+t = int(input())
+for _ in range(t):
+    n = int(input())
+    print(P[n])

--- a/study/baekjoon/week8/BOJ29715_비밀번호_찾기/BOJ29515_비밀번호_찾기_실버3_조재은.py
+++ b/study/baekjoon/week8/BOJ29715_비밀번호_찾기/BOJ29515_비밀번호_찾기_실버3_조재은.py
@@ -1,0 +1,27 @@
+import  math
+
+# n: 비밀번호의 자릿수, m: 비밀번호에 대해 기억하는 정보의 수
+n, m = map(int, input().split())
+
+# x: 비번 입력하는 데 걸리는 시간, y: 비번 3번 연속 실패 입력 시 비번 입력할 수 없는 시간
+x, y = map(int, input().split())
+
+pwCnt = 0
+cnt = 0
+
+for _ in range(m):
+    # m개 줄에 걸쳐 비밀번호에 대한 정보를 뜻하는 a, b
+    a, b = map(int, input().split())
+    if a != 0:   # a가 0이 아니면, a번째 자리의 값이 b라는 것을 의미
+        pwCnt += 1
+    else:       # a가 0이면 비번 중 한 자리의 값이 b라는 것을 의미
+        cnt += 1
+
+n -= pwCnt
+result = 1
+if cnt > 0:
+    result *= math.comb(n,cnt) * math.factorial(cnt)
+n -= cnt
+if n > 0:
+    result *= math.perm(9-(pwCnt+cnt), n)
+print(result * x + ((result -1) // 3) * y)

--- a/study/baekjoon/week8/BOJ29715_비밀번호_찾기/BOJ29515_비밀번호_찾기_실버3_조재은.py
+++ b/study/baekjoon/week8/BOJ29715_비밀번호_찾기/BOJ29515_비밀번호_찾기_실버3_조재은.py
@@ -6,8 +6,8 @@ n, m = map(int, input().split())
 # x: 비번 입력하는 데 걸리는 시간, y: 비번 3번 연속 실패 입력 시 비번 입력할 수 없는 시간
 x, y = map(int, input().split())
 
-pwCnt = 0
-cnt = 0
+pwCnt = 0      # 비밀번호의 특정 자리가 확정된 숫자의 개수입니다.
+cnt = 0        # 비밀번호에 포함되어야 하지만 자리가 확정되지 않은 숫자의 개수
 
 for _ in range(m):
     # m개 줄에 걸쳐 비밀번호에 대한 정보를 뜻하는 a, b
@@ -17,11 +17,19 @@ for _ in range(m):
     else:       # a가 0이면 비번 중 한 자리의 값이 b라는 것을 의미
         cnt += 1
 
-n -= pwCnt
+n -= pwCnt # 확정된 자리의 숫자를 제외한 남은 자리수를 업데이트
 result = 1
 if cnt > 0:
+    # n개의 자리 중에서 cnt개의 특정 숫자를 포함하는 조합의 수를 계산
+    # cnt개의 특정 숫자를 나열하는 순열의 수를 계산합니다.
     result *= math.comb(n,cnt) * math.factorial(cnt)
-n -= cnt
+    
+n -= cnt # 자리는 확정되지 않았지만 포함되어야 하는 숫자를 배치한 후의 남은 자리수를 업데이트
 if n > 0:
+    # 남은 자리수에 대해, 사용할 수 있는 숫자로 만들 수 있는 순열의 수를 계산합니다. 
+    # 여기서 9 - (pwCnt + cnt)는 아직 사용되지 않은 숫자의 개수 (0 ~9번까지에서 -1)
     result *= math.perm(9-(pwCnt+cnt), n)
+    
+# 계산된 비밀번호 조합의 수에 따라 비밀번호를 입력하는 데 걸리는 
+# 총 시간(result * x)과, 3회 연속 실패 후 대기하는 시간을 포함한 총 시간을 계산하고 출력
 print(result * x + ((result -1) // 3) * y)


### PR DESCRIPTION
입력 처리: 비밀번호의 자릿수 n, 기억하고 있는 정보의 수 m, 비밀번호 입력 시간 x, 그리고 비밀번호 입력에 실패한 후 대기하는 시간 y를 입력받습니다.

정보 처리: 비밀번호에 대한 정보를 입력받아, 비밀번호의 특정 자리가 확정된 경우와 비밀번호 중 하나의 숫자가 확정된 경우를 구분합니다. pwCnt는 비밀번호의 특정 자리가 확정된 숫자의 개수를 나타내고, cnt는 비밀번호에 포함되어야 하는 확정된 숫자의 개수입니다.

비밀번호 조합 계산:
1. math.comb(n, cnt): 확정된 숫자를 제외한 나머지 자리 중에서 cnt개를 선택하는 조합의 수입니다.
2. math.factorial(cnt): 확정된 숫자 cnt개를 나열하는 순열의 수입니다.
3. math.perm(9 - (pwCnt + cnt), n): 나머지 자리에 들어갈 수 있는 숫자의 순열입니다. 여기서 9 - (pwCnt + cnt)는 사용 가능한 숫자의 수입니다.
4. 최대 시간 계산: 계산된 비밀번호 조합의 수에 대해 각 비밀번호를 입력하는 데 걸리는 시간(result * x)과 실패 후 대기하는 시간을 합하여 최대 시간을 계산합니다.

### math.factorial(x):
x의 팩토리얼을 계산합니다. 팩토리얼은 1부터 x까지의 모든 정수의 곱을 의미합니다. 예를 들어, 5! (5의 팩토리얼)은 5 * 4 * 3 * 2 * 1 = 120입니다.
예) math.factorial(5)는 120을 반환합니다.

### math.comb(n, k):
n개의 다른 항목들 중에서 k개를 선택하는 방법의 수, 즉 조합의 수를 계산합니다. 조합은 순서를 고려하지 않습니다. 
예를 들어, {A, B, C}에서 2개를 선택하는 방법은 {A, B}, {A, C}, {B, C}의 3가지입니다.
예) math.comb(3, 2)는 3을 반환합니다.

### math.perm(n, k=None):
n개의 다른 항목들 중에서 k개를 선택하여 나열하는 방법의 수, 즉 순열의 수를 계산합니다. 
k가 지정되지 않으면 n으로 간주되어 n개 모두를 나열하는 순열의 수를 계산합니다. 
순열은 선택된 항목들의 순서를 고려합니다. 예를 들어, {A, B}에서 2개를 나열하는 방법은 (A, B)와 (B, A)의 2가지입니다.
예) math.perm(2)는 2를 반환하고, math.perm(3, 2)는 6을 반환합니다.